### PR TITLE
Fix/issue42 remove open sans stylesheet

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -5,7 +5,6 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
   <title>Lumi</title>
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->


### PR DESCRIPTION
Remove the stylesheet from index.html because it can not be loaded while offline. Font should be delivered by the express-server