### PR TITLE
add couchdb-attachment-proxy to server

### DIFF
--- a/server/controllers/api/cards.controller.ts
+++ b/server/controllers/api/cards.controller.ts
@@ -3,7 +3,9 @@ import { IRequest } from '../../middleware/auth';
 
 import Card from '../../models/Card';
 import Tag from '../../models/Tag';
+
 import { DB } from '../../db';
+import proxy from '../../core/proxy';
 
 import Controller from '../controller';
 
@@ -53,6 +55,20 @@ class CardController extends Controller<Card> {
             },
             Card
         );
+    }
+
+    public attachment(req: express.Request, res: express.Response) {
+        req.url =
+            '/' +
+            process.env.DB +
+            '/' +
+            req.params.id +
+            '/' +
+            req.params.attachment;
+
+        proxy.web(req, res, {
+            target: process.env.DB_HOST
+        });
     }
 }
 

--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -22,6 +22,7 @@ router.get('/user/auth/session', mw.auth, AuthController.get_session);
 router.get('/cards', CardsController.list);
 router.post('/cards', CardsController.create);
 router.get('/cards/:id', CardsController.read);
+router.get('/cards/:id/attachment/:attachment', CardsController.attachment );
 router.put('/cards/:id', CardsController.update);
 router.delete('/cards/:id', CardsController.delete);
 router.put('/cards/:id/action', CardsController.action);


### PR DESCRIPTION
couchdb allows attachments to be stored within the database. We need a way to access them from the client. This PR adds a proxy to the server that proxies all request from `/cards/:id/attachment/:attachment` to the corresponding couchdb-api. (http://docs.couchdb.org/en/2.0.0/api/document/attachments.html)

Closes one part of Issue #54