### PR TITLE
add couchdb-attachment-proxy

### DIFF
--- a/app/server/controllers/api/cards.controller.ts
+++ b/app/server/controllers/api/cards.controller.ts
@@ -1,6 +1,7 @@
 import * as express from 'express';
 import { IRequest } from '../../middleware/auth';
 
+import proxy from '../../core/proxy';
 import Card from '../../models/Card';
 import Tag from '../../models/Tag';
 import { DB } from '../../db';
@@ -53,6 +54,20 @@ class CardController extends Controller<Card> {
             },
             Card
         );
+    }
+
+    public attachment(req: express.Request, res: express.Response) {
+        req.url =
+            '/' +
+            process.env.DB +
+            '/' +
+            req.params.id +
+            '/' +
+            req.params.attachment;
+
+        proxy.web(req, res, {
+            target: process.env.DB_HOST
+        });
     }
 }
 

--- a/app/server/routes/api.ts
+++ b/app/server/routes/api.ts
@@ -25,6 +25,8 @@ router.get('/cards/:id', CardsController.read);
 router.put('/cards/:id', CardsController.update);
 router.delete('/cards/:id', CardsController.delete);
 router.put('/cards/:id/action', CardsController.action);
+// cards -> attachments
+router.all('/cards/:id/attachment/:attachment', CardsController.attachment);
 
 // collections
 router.get('/collections', CollectionController.list);


### PR DESCRIPTION
couchdb allows attachments to be stored within the database. We need a way to access them from the client. This PR adds a proxy to the server that proxies all request from /cards/:id/attachment/:attachment to the corresponding couchdb-api. (http://docs.couchdb.org/en/2.0.0/api/document/attachments.html)

Closes one part of Issue #54